### PR TITLE
Handle Curl Errors

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -23,5 +23,5 @@ variable "url" {
 
 variable "curl_arguments" {
   description = "Arguments that should get passed to `curl`"
-  default     = "-fsL"
+  default     = "-fL"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,5 +23,5 @@ variable "url" {
 
 variable "curl_arguments" {
   description = "Arguments that should get passed to `curl`"
-  default     = "-fL"
+  default     = "-fsSL"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,5 +23,5 @@ variable "url" {
 
 variable "curl_arguments" {
   description = "Arguments that should get passed to `curl`"
-  default     = "-sSL"
+  default     = "-fsL"
 }


### PR DESCRIPTION
## what
* `curl` should exit non-zero on errors

## why
* So terraform knows there's an error
